### PR TITLE
Change installation mode from go to binaries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-sachet_version: latest
+sachet_version: 0.2.2
 
 sachet_instance: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
 
 sachet_address: "127.0.0.1"
 sachet_port: 9876
 
-sachet_repository: "github.com/messagebird/sachet/cmd/sachet"
+sachet_repository: "github.com/messagebird/sachet"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,4 +45,4 @@
   with_items:
     - sachet
   notify:
-    - restart alertmanager
+    - restart sachet

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,20 +14,35 @@
     group: sachet
     createhome: false
 
-- name: Install dependencies
-  package:
-    name: "{{ sachet_dependencies }}"
-    state: present
+- name: download sachet binary to local folder
+  become: false
+  get_url:
+    url: "https://{{ sachet_repository }}/releases/download/{{ sachet_version }}/sachet-{{ sachet_version }}.linux-{{ go_arch }}.tar.gz"
+    dest: "/tmp/sachet-{{ sachet_version }}.linux-{{ go_arch }}.tar.gz"
+  register: _download_archive
+  until: _download_archive is succeeded
+  retries: 5
+  delay: 2
+  delegate_to: localhost
+  check_mode: false
 
-- name: Get Sachet
-  command: "go get -u {{ sachet_repository }}"
-  environment:
-    GOPATH: "{{ ansible_env.HOME}}/go"
+- name: unpack sachet binaries
+  become: false
+  unarchive:
+    src: "/tmp/sachet-{{ sachet_version }}.linux-{{ go_arch }}.tar.gz"
+    dest: "/tmp"
+    creates: "/tmp/sachet-{{ sachet_version }}.linux-{{ go_arch }}"
+  delegate_to: localhost
+  check_mode: false
 
-- name: Install Sachet
+- name: propagate sachet binaries
   copy:
-    remote_src: yes
-    src: "{{ ansible_env.HOME }}/go/bin/sachet"
-    dest: /usr/local/bin/sachet
-    mode: '0755'
-  notify: restart sachet
+    src: "/tmp/sachet-{{ sachet_version }}.linux-{{ go_arch }}/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    mode: 0755
+    owner: root
+    group: root
+  with_items:
+    - sachet
+  notify:
+    - restart alertmanager

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: Gather variables for each operating system
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
-
 - include: install.yml
   become: true
   tags:

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,4 +1,0 @@
----
-sachet_dependencies:
-  - golang-go
-  - git


### PR DESCRIPTION
Hi, 
Thanks for your role.
I don't want to install go-lang on my server so I change the installation mode to directly download binary from github.
This is tha way prometheus components are installed in official roles (cloudalchemy)

Yoann