### PR TITLE
Add meta information for Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
     versions:
     - jessie
     - stretch
+    - buster
   - galaxy_tags:
     - system
     - monitoring

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: Finwë
+  description: Sachet
+  license: MIT
+  company: none
+  min_ansible_version: 2.5
+  platforms:
+  - name: Ubuntu
+    versions:
+    - bionic
+    - xenial
+  - name: Debian
+    versions:
+    - jessie
+    - stretch
+  - galaxy_tags:
+    - system
+    - monitoring
+    - prometheus
+    - alerting
+
+dependencies: []


### PR DESCRIPTION
This file is required to install role throught ansible-galaxy install -r requirements.yml even if the role is not published on Galaxy
(PR from master containing only this modification)